### PR TITLE
Prevent dereference of null in fetch error handling

### DIFF
--- a/src/redux/sagas/spotify.js
+++ b/src/redux/sagas/spotify.js
@@ -290,15 +290,21 @@ function * spotifyApiCall({url, method, body}) {
 
 		return null;
 	} catch (fetchError) {
-		if (fetchError.message === error401) {
+		if (!fetchError) {
+			yield put({
+				type: spotifyActions.SPOTIFY_API_REQUEST_ERROR,
+				payload: 'Unknown Spotify API error'
+			});
+		} else if (fetchError.message === error401) {
 			yield put({
 				type: spotifyActions.SPOTIFY_AUTH_REQUIRED
 			});
+		} else {
+			yield put({
+				type: spotifyActions.SPOTIFY_API_REQUEST_ERROR,
+				payload: fetchError.message || 'Unknown Spotify API error' + fetchError
+			});
 		}
-		yield put({
-			type: spotifyActions.SPOTIFY_API_REQUEST_ERROR,
-			payload: fetchError.message || 'Unknown Spotify API error' + fetchError
-		});
 	}
 }
 


### PR DESCRIPTION
I was seeing 404 responses on searches with no results (or something like that). For some reason this leads to a null object in the exception handler.

This triggers a de-reference issue which cascades out of the handler and prevents any further requests being made.

This pull request has one possible solution for handling that case. Not 100% sure if this is the best way of handling the root cause.