### PR TITLE
removed invalid scope

### DIFF
--- a/server/soundbounce/auth.js
+++ b/server/soundbounce/auth.js
@@ -21,7 +21,6 @@ const stateKey = 'spotify_auth_state',
 		'user-library-read',
 		'user-library-modify',
 		'user-read-private',
-		'user-read-birthdate',
 		'user-read-email',
 		'user-top-read'
 	];


### PR DESCRIPTION
user-read-birthdate is no longer supported by the spotify APIs and results in "Illegal Scope" message which prevents login. Removal allows login to work